### PR TITLE
Fix iteration bug in variational network

### DIFF
--- a/variational_network.py
+++ b/variational_network.py
@@ -151,7 +151,7 @@ class VariationalNetwork(nn.Module):
 
         for k in range(self.n_layers):
             
-            g = self.compute_g(x0, s, mask, i2k, k2i, k)
+            g = self.compute_g(x, s, mask, i2k, k2i, k)
             m = self.update_momentum(m, g, k)
             x = self.update_x(x, m)
 


### PR DESCRIPTION
## Summary
- fix forward() so each layer uses the latest iterate when computing gradients

## Testing
- `python -m py_compile variational_network.py utils.py projectB.py`

------
https://chatgpt.com/codex/tasks/task_e_6840154367588329881e342a1c2745ec