### PR TITLE
Fix dtype mismatch and interpolation

### DIFF
--- a/projectB.py
+++ b/projectB.py
@@ -50,10 +50,10 @@ class HeartDataset(Dataset):
                                                     sigma=self.noise_std)
 
         img_t = torch.from_numpy(img.transpose(2, 0, 1))  # (T, H, W)
-        real = np.real(s).transpose(2, 0, 1)
-        imag = np.imag(s).transpose(2, 0, 1)
+        real = np.real(s).astype(np.float32).transpose(2, 0, 1)
+        imag = np.imag(s).astype(np.float32).transpose(2, 0, 1)
         s_t = torch.from_numpy(np.stack([real, imag], axis=0))  # (2, T, H, W)
-        mask_t = torch.from_numpy(mask.transpose(2, 0, 1))
+        mask_t = torch.from_numpy(mask.transpose(2, 0, 1).astype(np.float32))
         return img_t, s_t, mask_t
 
 


### PR DESCRIPTION
## Summary
- ensure k-space data from `HeartDataset` is float32
- implement manual activation interpolation without `torch.interp`

## Testing
- `python -m py_compile projectB.py utils.py variational_network.py`
- `python - <<'EOF'
import torch
from variational_network import VariationalNetwork
from utils import k2i_torch, i2k_torch
T,H,W=2,4,4
x0=torch.randn(T,H,W)
mask=torch.ones(H,W,T)
s=torch.randn(H,W,T,dtype=torch.complex64)
model=VariationalNetwork(n_layers=1,n_filters=2)
print('x0 dtype',x0.dtype)
out=model(x0,s,i2k_torch,k2i_torch,mask)
print('out dtype',out.dtype)
EOF

------
https://chatgpt.com/codex/tasks/task_e_6840472fa3048329b7c74a19310ca966