### PR TITLE
Implement deep supervision loss in training

### DIFF
--- a/projectB.py
+++ b/projectB.py
@@ -22,6 +22,7 @@ NUM_EPOCHS   = 50
 LR           = 1e-2
 PRINT_EVERY  = 10
 TRAIN_SPLIT  = 0.8
+DS_TAU       = 0.1
 #─────────────────────────────────────────────────────────────────────────────
 
 
@@ -90,13 +91,21 @@ def train_vn(num_epochs=NUM_EPOCHS, lr=LR, batch_size=BATCH_SIZE):
             m = m.permute(0, 2, 3, 1).to(device)
 
             x0 = k2i_torch(s_complex)
-            pred = vn(x0, s_complex, i2k_torch, k2i_torch, m)
+            pred, preds_all = vn(x0, s_complex, i2k_torch, k2i_torch, m,
+                                 return_intermediate=True)
 
-            loss = torch.mean(torch.abs(torch.abs(pred) - torch.abs(gt)))
+            plot_loss = torch.mean(torch.abs(torch.abs(pred) - torch.abs(gt)))
+
+            K = len(preds_all)
+            ds_loss = 0.0
+            for k, x_k in enumerate(preds_all, start=1):
+                weight = torch.exp(-DS_TAU * (K - k))
+                ds_loss = ds_loss + weight * F.mse_loss(x_k, gt)
+
             optim.zero_grad()
-            loss.backward()
+            ds_loss.backward()
             optim.step()
-            running += loss.item()
+            running += plot_loss.item()
 
         epoch_loss = running / len(train_loader)
         losses.append(epoch_loss)

--- a/variational_network.py
+++ b/variational_network.py
@@ -218,15 +218,21 @@ class VariationalNetwork(nn.Module):
         return x - m_next
 
 
-    def forward(self, x0, s, i2k, k2i, mask):
-        
+    def forward(self, x0, s, i2k, k2i, mask, return_intermediate=False):
+
         x = x0.clone()
         m = torch.zeros_like(x0)  # Initialize momentum
 
+        xs = []
         for k in range(self.n_layers):
-            
+
             g = self.compute_g(x, s, mask, i2k, k2i, k)
             m = self.update_momentum(m, g, k)
             x = self.update_x(x, m)
 
+            if return_intermediate:
+                xs.append(x.clone())
+
+        if return_intermediate:
+            return x, xs
         return x


### PR DESCRIPTION
## Summary
- extend `VariationalNetwork.forward` to optionally return intermediate results
- add `DS_TAU` hyperparameter
- train VN using deep supervision loss while still plotting the original L1 loss

## Testing
- `python -m py_compile projectB.py utils.py variational_network.py`

------
https://chatgpt.com/codex/tasks/task_e_68413eaae0788329bba67e3f91b68439