### PR TITLE
Update thesis layout

### DIFF
--- a/Inverse Bonus Project/introduction.tex
+++ b/Inverse Bonus Project/introduction.tex
@@ -62,13 +62,13 @@ I tried 3, 5 and 10 layers for the following fixed parameters.
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/training_loss_different_n_layers.png}
+  \includegraphics[width=0.45\linewidth]{data/training_loss_different_n_layers.png}
   \caption{Training and validation loss for fixed parameters with different number of layers.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/nRMSE_loss.png}
+  \includegraphics[width=0.45\linewidth]{data/nRMSE_loss.png}
   \caption{nRMSE for fixed parameters with different number of layers.}
 \end{figure}
 
@@ -76,25 +76,25 @@ The loss decreased for deeper networks as expected. Increasing the number of fil
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/training_validation_differnt_n_filter.png}
+  \includegraphics[width=0.45\linewidth]{data/training_validation_differnt_n_filter.png}
   \caption{Training and validation loss for different numbers of filters and kernel sizes.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/mRMSE_different_n_filrters_size.png}
+  \includegraphics[width=0.45\linewidth]{data/mRMSE_different_n_filrters_size.png}
   \caption{nRMSE for different numbers of filters and kernel sizes.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/learning_loss 1.png}
+  \includegraphics[width=0.45\linewidth]{data/learning_loss 1.png}
   \caption{Training loss for a 4\,x\,4 kernel with 10 layers, 5 filters and 25 epochs.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/reconstruction loss.png}
+  \includegraphics[width=0.45\linewidth]{data/reconstruction loss.png}
   \caption{Training loss for a 3\,x\,3 kernel with 10 layers, 5 filters and 25 epochs.}
 \end{figure}
 
@@ -125,19 +125,19 @@ Hyperparameters were identical except for the regulariser.
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/2 - Zettelkasten/1 - Atomic Notes/Assets/learning_loss.png}
+  \includegraphics[width=0.45\linewidth]{data/2 - Zettelkasten/1 - Atomic Notes/Assets/learning_loss.png}
   \caption{VTV training $\ell_1$ loss.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/training_loss 3.png}
+  \includegraphics[width=0.45\linewidth]{data/training_loss 3.png}
   \caption{Tikhonov training $\ell_1$ loss.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/tv_training_loss.png}
+  \includegraphics[width=0.45\linewidth]{data/tv_training_loss.png}
   \caption{TV training loss.}
 \end{figure}
 
@@ -145,13 +145,13 @@ The VN with the VTV regulariser achieved a training loss of 0.019454, a validati
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/training_loss_vtv_vs_tv.png.png}
+  \includegraphics[width=0.45\linewidth]{data/training_loss_vtv_vs_tv.png.png}
   \caption{Training loss for VTV and TV regularisers for different noise and acceleration parameters.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/validation_loss_vtv_vs_tv.png}
+  \includegraphics[width=0.45\linewidth]{data/validation_loss_vtv_vs_tv.png}
   \caption{Validation error (nRMSE) for VTV and TV regularisers for different noise and acceleration parameters.}
 \end{figure}
 
@@ -168,25 +168,25 @@ Hyperparameters:
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/training_loss 8.png}
+  \includegraphics[width=0.45\linewidth]{data/training_loss 8.png}
   \caption{Training loss of the VN with deep supervision.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/training_loss 9.png}
+  \includegraphics[width=0.45\linewidth]{data/training_loss 9.png}
   \caption{Training loss of the VN without deep supervision.}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/reconstruction_example 10.png}
+  \includegraphics[width=0.45\linewidth]{data/reconstruction_example 10.png}
   \caption{Example reconstruction images (without deep supervision).}
 \end{figure}
 
 \begin{figure}[h]
   \centering
-  \includegraphics[width=0.6\linewidth]{data/reconstruction_example 9.png}
+  \includegraphics[width=0.45\linewidth]{data/reconstruction_example 9.png}
   \caption{Example reconstruction images (without deep supervision).}
 \end{figure}
 

--- a/Inverse Bonus Project/layoutsetup.tex
+++ b/Inverse Bonus Project/layoutsetup.tex
@@ -84,14 +84,7 @@
 \renewcommand{\maketitlehookb}{\vspace{1in}%
   \par\begin{center}\Large\sffamily\@thesistype\end{center}}
 
-\renewcommand{\maketitlehookd}{%
-  \vfill\par
-  \begin{flushright}
-    \sffamily
-    \@advisors\par
-    \@department, ETH Z\"urich
-  \end{flushright}
-}
+\renewcommand{\maketitlehookd}{\vfill\par}
 
 \checkandfixthelayout
 

--- a/Inverse Bonus Project/thesis.tex
+++ b/Inverse Bonus Project/thesis.tex
@@ -6,7 +6,7 @@
 
 
 %% We use the memoir class because it offers a many easy to use features.
-\documentclass[11pt,a4paper,titlepage]{memoir}
+\documentclass[11pt,a4paper,titlepage,openany]{memoir}
 
 %% Packages
 %% ========
@@ -97,9 +97,7 @@
 \end{titlingpage}
 
 
-%% TOC with the proper setup, do not change.
-\cleartorecto
-\tableofcontents
+%% Main matter starts directly without a table of contents.
 \mainmatter
 
 %% Your real content!
@@ -110,6 +108,5 @@
 \bibliographystyle{plain}
 \bibliography{refs}
 
-\includepdf[pages={-}]{declaration-originality.pdf}
 
 \end{document}


### PR DESCRIPTION
## Summary
- stop printing advisor and department on the title page
- start main matter directly and omit the table of contents
- drop the declaration of originality page
- shrink figures to make them fit side by side
- allow chapters to start on any page

## Testing
- `pytest`
- `python -m py_compile projectB.py utils.py variational_network.py`


------
https://chatgpt.com/codex/tasks/task_e_684a8a20019483298a7dd92b4d16804a